### PR TITLE
Stop bundling openjpeg

### DIFF
--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -49,25 +49,6 @@
       ]
     },
     {
-      "name": "libopenjpeg",
-      "buildsystem": "cmake-ninja",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz",
-          "sha256": "63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9"
-        }
-      ],
-      "cleanup": [
-	      "/lib/pkgconfig",
-	      "/lib/openjpeg-*",
-	      "/lib/debug",
-	      "/include",
-	      "*.a",
-	      "*.la"
-      ]
-    },
-    {
       "name": "libpoppler-glib",
       "buildsystem": "cmake-ninja",
       "sources": [


### PR DESCRIPTION
It is already in the 3.34 GNOME runtime.