### PR TITLE
Upgrade to Gnome platform version 3.36.

### DIFF
--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.claws_mail.Claws-Mail",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.34",
+  "runtime-version": "3.36",
   "sdk": "org.gnome.Sdk",
   "command": "claws-mail",
   "finish-args": [


### PR DESCRIPTION
Upgrade to Gnome platform 3.36.
Updated shared modules to latest version.