### PR TITLE
Enabling debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,12 @@
 # flatpak packaging instructions.
 #
 # SPDX-License-Identifier: MIT
-.PHONY: install uninstall run validate clean distclean shell
+.PHONY: install uninstall build-shell run run-shell validate clean distclean shell
 
 APPID = org.claws_mail.Claws-Mail
 RUNCMD = /app/bin/claws-mail-wrapper.sh
 
+# Prescribed variables: changing these is not necessary.
 APPDATA = $(APPID).appdata.xml
 BUNDLE = $(APPID).bundle
 MANIFEST = $(APPID).json
@@ -15,15 +16,18 @@ build: $(MANIFEST) $(APPDATA) flathub.json static/*
 	flatpak-builder --sandbox --force-clean build $(MANIFEST)
 	touch build
 
-shell: build
+build-shell: build
 ifeq ($(MODULE),)
 	@echo "MODULE=modulename is missing."
 	@exit 1
 endif
-	flatpak-builder --sandbox --force-clean --build-shell=$(MODULE) build $(MANIFEST)
+	flatpak-builder --sandbox --build-shell=$(MODULE) build $(MANIFEST)
 
 run: build
 	flatpak-builder --run build $(MANIFEST) $(RUNCMD)
+
+run-shell: build
+	flatpak-builder --run build $(MANIFEST) /bin/sh
 
 install: build
 	flatpak-builder --sandbox --export-only --user --install build -y $(MANIFEST)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 The flathub recipe for building [Claws-Mail](https://claws-mail.org) as a flatpak distributable package.
 
+Debug extension: `org.claws_mail.Claws_Mail.Debug`. (`flatpak install flathub org.claws_mail.Claws_Mail.Debug`)  
+The [flatpak documentation on debugging](https://docs.flatpak.org/en/latest/debugging.html) explains debugging flatpaks in more detail.
+
 ## Functionality
 
 Claws-Mail with the following plug-ins:

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -26,7 +26,6 @@
         }
       ],
       "cleanup": [
-	      "/lib/debug",
 	      "/include",
 	      "*.a",
 	      "*.la"
@@ -44,7 +43,6 @@
       ],
       "cleanup": [
 	      "/lib/pkgconfig",
-	      "/lib/debug",
 	      "/include",
 	      "*.a",
 	      "*.la"
@@ -63,7 +61,6 @@
       "cleanup": [
 	      "/lib/pkgconfig",
 	      "/lib/openjpeg-*",
-	      "/lib/debug",
 	      "/include",
 	      "*.a",
 	      "*.la"
@@ -81,7 +78,6 @@
       ],
       "cleanup": [
 	      "/lib/pkgconfig",
-	      "/lib/debug",
 	      "/include",
 	      "*.a",
 	      "*.la"
@@ -99,7 +95,6 @@
       ],
       "cleanup": [
 	      "/lib/pkgconfig",
-	      "/lib/debug",
 	      "/lib/cmake",
 	      "/include",
 	      "*.a",
@@ -118,7 +113,6 @@
       ],
       "cleanup": [
 	      "/lib/pkgconfig",
-	      "/lib/debug",
 	      "/include",
 	      "*.a",
 	      "*.la"
@@ -142,7 +136,6 @@
       ],
       "cleanup": [
 	      "/lib/pkgconfig",
-	      "/lib/debug",
 	      "/include",
 	      "*.a",
 	      "*.la"
@@ -160,7 +153,6 @@
       ],
       "cleanup": [
 	      "/lib/pkgconfig",
-	      "/lib/debug",
 	      "/include",
 	      "*.a",
 	      "*.la"
@@ -179,7 +171,6 @@
         ],
         "cleanup": [
             "/libexec/*",
-            "/lib/debug",
             "/lib/pkgconfig",
             "/include",
             "*.a",
@@ -199,7 +190,6 @@
         ],
         "cleanup": [
             "/libexec/*",
-            "/lib/debug",
             "/lib/pkgconfig",
             "/include",
             "*.a",
@@ -223,7 +213,6 @@
       ],
       "cleanup": [
 	      "/libexec/*",
-	      "/lib/debug",
 	      "/lib/pkgconfig",
 	      "/include",
 	      "*.a",
@@ -255,7 +244,6 @@
         }
       ],
       "cleanup": [
-	      "/lib/debug"
       ]
     },
     {


### PR DESCRIPTION
Improves on issue #19.

The debug extension is provided with an inconsistent package name: `org.claws_mail.Claws_Mail.Debug`. (with two underscores)

In addition, prevent cleaning up the various 'lib/debug' directories such that they can be packaged in `.Debug`.

Mention name of `.Debug` extension in README.md and include reference to flatpak debugging documentation, for convenience.