### PR TITLE
Next

### DIFF
--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -5,6 +5,7 @@
   "sdk": "org.freedesktop.Sdk",
   "command": "/app/bin/claws-mail",
   "finish-args": [
+    "--device=dri",
     "--share=ipc",
     "--share=network",
     "--socket=x11",


### PR DESCRIPTION
Upgrade to __Claws-Mail 4.0.0__ and `org.freedesktop.Platform//21.08`.

- Updated remaining dependencies:
  - libgdata
  - poppler
- Removal of `pinentry`, `pcsc-lite`.
- Rely on host-based `gpg-agent`. (Needs to be running.)