### PR TITLE
Upgrade to Claws-Mail 4.3.0, runtime 23.08

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,8 @@ uninstall:
 	flatpak uninstall -y --user $(APPID)//local-build
 
 # Validate appdata-file to appstream validation rules.
-# TODO: is there an lighter way than 'flatpak info' to test for installed flatpak package?
 validate:
 	@(type appstream-util 1>/dev/null 2>&1 && (appstream-util validate $(APPDATA) || true)) || \
-		(flatpak info org.freedesktop.appstream-glib 1>/dev/null 2>&1 && (flatpak run org.freedesktop.appstream-glib validate $(APPDATA) || true)) || \
 		echo "'appstream-util' cannot be found. This is needed for \"appdata\" metadata validation."
 
 distclean: clean

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Disabled plug-ins due to unresolved dependencies:
 - BSFilter (assumes `bsfilter` is available)
 - Perl (assumes `perl` is available)
 
+## Contributions
+
+With contributions and feedback by:
+
+- [scabala](<https://github.com/scabala>)
+
 ## TODO
 
 Reminders for later consideration.

--- a/org.claws_mail.Claws-Mail.appdata.xml
+++ b/org.claws_mail.Claws-Mail.appdata.xml
@@ -67,6 +67,75 @@
   </screenshots>
 
   <releases>
+    <release version="4.3.0" date="2024-06-10">
+      <description>
+        <p>Claws-Mail updated to 4.3.0.</p>
+        <ul>
+          <li>Compose window: when the focus is in the message text, copied files can be pasted as attachments using /Edit/paste or Ctrl+V. (The context menu's Paste will still insert the list of files into the message body.)</li>
+          <li>'/Mark/Mark all read in folder' and 'Mark/Mark all unread in folder' have been re-added to the Message List context menu.</li>
+          <li>It is now possible to use '/Tools/Remove references' when forwarding mail.</li>
+          <li>Keyboard shortcuts: The "Choose preset keyboard shortcuts" selector has been integrated into the main preferences page. When 'Current' is the selected preset, Apply/OK will keep the existing settings.</li>
+          <li>An MBOX file can now be imported from the command line using `claws-mail --import-mbox %f` where %f is the full path to the MBOX file.</li>
+          <li>OAUTH2 support for Microsoft 365 GCC High has been added.</li>
+          <li>LiteHTML Viewer plugin: Updated to LiteHTML 0.9.</li>
+          <li>The menurc file is now backed-up on startup.</li>
+          <li>Removed support for the obsolete Avant Window Navigator.</li>
+          <li>Various code cleanups.</li>
+          <li>The manual has been updated.</li>
+          <li>New translation: Albanian.</li>
+          <li>Updated translations: Catalan, Czech, French, Hungarian, Indonesian, Polish, Romanian, Slovak, Spanish, Swedish, Turkish.</li>
+        </ul>
+        <p>Bug fixes</p>
+        <ul>
+          <li>bug 4668, 'Sometimes, at program start, message list takes all the vertical space'</li>
+          <li>bug 4720, 'matcher: release regex_t in matcherprop_string_match'</li>
+          <li>bug 4724, 'set proper availability status to sign/encrypt toolbar buttons'</li>
+          <li>bug 4725, 'oauth2: remove trailing zero from transmit buffer in oauth2_contact_server'</li>
+          <li>bug 4728, 'socket: handle GNUTLS_E_PREMATURE_TERMINATION in ssl_read'</li>
+          <li>bug 4730, 'oauth2: fix string handling in oauth2_contact_server'</li>
+          <li>bug 4733, 'Line breaks lost in headers'</li>
+          <li>bug 4734, 'ssl_certificate: remove unhelpful warnings from certificate check'</li>
+          <li>bug 4746, 'matcher: remove incorrect condition in matcherprop_free'</li>
+          <li>bug 4747, 'matcher: simplify matcherprop_new'</li>
+          <li>bug 4749, 'release regex_t in summary_compile_simplify_regexp'</li>
+          <li>bug 4750, 'remove regcomp wrapper and call regcomp directly'</li>
+          <li>bug 4752, 'Adjust incorrect debug_printf call in pgp plugins'</li>
+          <li>bug 4754, 'text/enriched literal less-than sign sequence handled incorrectly</li>
+          <li>bug 4757, 'remove AX_FUNC_MKDIR'</li>
+          <li>bug 4758, 'remove unused check for bind_textdomain_codeset'</li>
+          <li>bug 4759, 'remove unused function checks from AC_CHECK_FUNCS'</li>
+          <li>bug 4760, 'use correct type for move_bar_id'</li>
+          <li>bug 4762, 'oauth2: preserve an existing refresh token'</li>
+          <li>bug 4765, 'only store smtp auth if authorization method is OAUTH2'</li>
+          <li>bug 4766, 'preserve the expiry value of SMTP auth type is not OAUTH2'</li>
+          <li>bug 4768, 'Adjust logic while evaluating enable_avatars'</li>
+          <li>bug 4770, 'remove intl from list of include directories'</li>
+          <li>bug 4773, 'remove obsolescent AC_C_CONST'</li>
+          <li>bug 4780, 'use proper prototype for two archiver functions'</li>
+          <li>bug 4781, 'use correct prototype for privacy_free_signature_data'</li>
+          <li>bug 4782, 'use correct prototype for stop_archiving'</li>
+          <li>bug 4786, 'remove type confusion in getsockopt call in sock_connect_async_cb'</li>
+          <li>bug 4787, 'Use correct function for memory transfer in crypt_cfb_buf'</li>
+          <li>bug 4788, '"Change primary passphrase" disabled status handling'</li>
+          <li>bug 4790, 'widget spacing in "Changing primary passphrase" dialog'</li>
+          <li>bug 4791, 'remove obsolete glib version check'</li>
+          <li>bug 4795, 'Please remove -no-cpp-precomp flag for Apple'</li>
+          <li>bug 4796, 'URL with wide character doesn't work'</li>
+          <li>bug 4798, 'Quoting wrong when format=flowed and respect_flowed_format is set'</li>
+          <li>CIDs 1220325, 1491306 and 1491315, 'Explicit null dereferenced (FORWARD_NULL)'</li>
+          <li>CIDs 1491064, 1491074, 1491211, 1491105, 1491139, 1491164, 1491166, 1491168, 1491169, 1491178, 1491232, 1491242, 1492281 and 1591844 'Use after free (USE_AFTER_FREE)'</li>
+          <li>CID 1491137 'Out-of-bounds access (OVERRUN)'</li>
+          <li>CID 1591952 values overwritten before being used</li>
+          <li>CID 1596594 (CHECKED_RETURN)</li>
+          <li>CID 1596595 'Resource leak'</li>
+          <li>errors caused by invalid MIME viewer command-line</li>
+          <li>building on non-X11 systems</li>
+          <li>Use CFLAGS provided by nettle.pc</li>
+          <li>Fancy plugin, recognise mid and data embedded images</li>
+        </ul>
+        <p>For further details of the numbered bugs and RFEs listed above see https://www.claws-mail.org/bug/[BUG NUMBER]</p>
+      </description>
+    </release>
     <release version="4.2.0" date="2023-11-20">
       <description>
       <p>Claws-Mail updated to 4.2.0.</p>

--- a/org.claws_mail.Claws-Mail.appdata.xml
+++ b/org.claws_mail.Claws-Mail.appdata.xml
@@ -5,7 +5,9 @@
   <name>Claws-Mail</name>
   <project_license>GPL-3.0-only</project_license>
   <metadata_license>CC0-1.0</metadata_license>
-  <developer_name>The Claws Mail Team</developer_name>
+  <developer id="org.claws-mail">
+    <name>The Claws Mail Team</name>
+  </developer>
   <summary>Claws Mail is an email client (and news reader), based on GTK+</summary>
   <url type="homepage">https://claws-mail.org/</url>
 
@@ -25,42 +27,97 @@
     <p>This is an unofficial package. (See package metadata for details.)</p>
   </description>
 
-  <icon type="remote" height="128" width="128">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/share/icons/hicolor/128x128/apps/claws-mail.png</icon>
-  <icon type="remote" height="64" width="64">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/share/icons/hicolor/64x64/apps/claws-mail.png</icon>
-  <icon type="remote" height="48" width="48">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/share/icons/hicolor/48x48/apps/claws-mail.png</icon>
+  <icon type="remote" height="128" width="128">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/static/claws-mail-128x128.png</icon>
+  <icon type="remote" height="64" width="64">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/static/claws-mail-64x64.png</icon>
+  <icon type="remote" height="48" width="48">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/static/claws-mail-48x48.png</icon>
   
   <launchable type="desktop-id">org.claws_mail.Claws-Mail.desktop</launchable>
 
   <screenshots>
-    <screenshot>
+    <screenshot type="default">
       <image type="source">
         https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-main-window.png
       </image>
+      <caption>The main window</caption>
     </screenshot>
     <screenshot>
       <image type="source">
         https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-compose-window.png
       </image>
+      <caption>The compose window</caption>
     </screenshot>
     <screenshot>
       <image type="source">
         https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-reading-mail.png
       </image>
+      <caption>The separate message view</caption>
     </screenshot>
     <screenshot>
       <image type="source">
         https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-current-features.png
       </image>
+      <caption>The currenlty supported features</caption>
     </screenshot>
     <screenshot>
       <image type="source">
         https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-current-plugins.png
       </image>
+      <caption>The currenlty enabled plugins</caption>
     </screenshot>
   </screenshots>
 
   <releases>
+    <release version="4.2.0" date="2023-11-20">
+      <description>
+      <p>Claws-Mail updated to 4.2.0.</p>
+      <ul>
+        <li>An easy way to open any folder on start-up has been added: Right-click a folder and choose 'Open on start-up'. This can also be configured on the 'Folder list' tab of the /Configuration/Preferences/Display/Summaries page.</li>
+        <li>Spam statistics have been added to the session statistics.</li>
+        <li>It is now possible to save message attachments only, without the other message parts.</li>
+        <li>QuickSearch: support for a "v H V" search expression has been added and the 'y S' expression has been removed ('v X-Label S' can be used instead).</li>
+        <li>font/* and chemical/* MIME types are now recognised.</li>
+        <li>The image viewer now works correctly when not auto-loading images.</li>
+        <li>Icon Themes: it is no longer possible to install or remove system themes.</li>
+        <li>IMAP: Support for SCRAM-SHA-{224,256,384,512} authentication</li>
+        <li>mechanisms has been added.</li>
+        <li>IMAP: The statusbar now shows that expunge is happening.</li>
+        <li>The GData plugin has been removed.</li>
+        <li>The Fancy plugin no longer requires libsoup or libsoup-gnome.</li>
+        <li>The LiteHTML Viewer plugin has been synchronised with litehtml 0.7.</li>
+        <li>The LiteHTML viewer plugin will now only be built automatically if libgumbo 0.12 or newer is available. Building with libgumbo 0.10 must be explicitly requested using --enable-litehtml_viewer-plugin.</li>
+        <li>For extra debug output use --enable-more-addressbook-debug and --enable-more-ldap-debug.</li>
+        <li>Added translation: Portuguese</li>
+        <li>Updated translations: Brazilian Portuguese, Catalan, Czech, French, Polish, Russian, Slovak, Spanish, Swedish, Traditional Chinese, Turkish.</li>
+      </ul>
+      <p>Bug fixes</p>
+      <ul>
+        <li>bug 4491, 'address autocompletion list does not expand in height with the number of matches'</li>
+        <li>bug 4618, 'Rate limit by remote breaks queued/marked actions (Delete/Move)'</li>
+        <li>bug 4631, 'Embedding external editor crashes Claws-Mail on Wayland'</li>
+        <li>bug 4637, 'Segmentation fault when using SUMMARY is empty'</li>
+        <li>bug 4645, 'fails to check for perl-ExtUtils::Embed'</li>
+        <li>bug 4648, 'fails to build with gcc 13'</li>
+        <li>bug 4658, 'Headers unfolded incorrectly in message view'</li>
+        <li>bug 4664, 'OAUTH2 overwrites passwords even for plaintext logins'</li>
+        <li>bug 4666, 'fancy plugin doesn't build with libwebkit2gtk-4.1'</li>
+        <li>bug 4670, 'To/CC incorrectly escaped with a trailing backslash'</li>
+        <li>bug 4679, 'The correct date header is interpreted incorrectly to display strange date.'</li>
+        <li>bug 4693, 'Hang and crash when enable disable SVG Rendering prefs'</li>
+        <li>when starting with msgview hidden, toggling msgview to show it would use incorrect height</li>
+        <li>update quicksearch history list when changing type </li>
+        <li>wrong message which is shown when mail can't be sent</li>
+        <li>when redirecting, disable queueing</li>
+        <li>arbitrary paste restriction</li>
+        <li>when queueing or drafting a msg with an attachment which no longer exists, use the correct label on the button of the warning dialogue</li>
+        <li>using a custom header in found_in_addressbook match expressions</li>
+        <li>URIs may contain the '$' dollar sign</li>
+        <li>OAuth2, Update on-disk tokens as well when in-memory tokens are updated</li>
+        <li>Microsoft POP3 OAuth2 protocol</li>
+      </ul>
+      </description>
+    </release>
     <release version="4.1.0" date="2022-04-03">
+      <description>
       <p>Claws-Mail updated to 4.1.0.</p>
       <ul>
         <li>>Text zooming in the Message View is now possible, using CTRL+mouse wheel up/down, CRTL+touchpad two-fingered vertical swiping, or the Message View's right-click menu.</li>
@@ -119,8 +176,10 @@
         <li>weird logic with the 'Edit filter action' dialog</li>
         <li>resource leaks; memory corruption</li>
       </ul>
+      </description>
     </release>
     <release version="4.0.0-1" date="2021-11-20">
+      <description>
         <p>Claws-Mail 4.0.0</p>
         <ul>
             <li>First release using GTK-3 toolkit.</li>
@@ -132,13 +191,16 @@
             <li>Spell-checking support enabled.</li>
             <li>Extended notifications support enabled.</li>
         </ul>
+      </description>
     </release>
     <release version="4.0.0" date="2021-11-12">
+      <description>
         <p>Claws-Mail updated to 4.0.0</p>
         <ul>
             <li>First release using GTK-3 toolkit.</li>
         </ul>
-        <p><i>Flatpak packaging note</i>: the gpg-agent will no longer be started inside the flatpak package if it is not running. Please make sure that gpg-agent is running on the host system if you rely on access to smartcards/security keys.</p>
+        <p><em>Flatpak packaging note</em>: the gpg-agent will no longer be started inside the flatpak package if it is not running. Please make sure that gpg-agent is running on the host system if you rely on access to smartcards/security keys.</p>
+      </description>
     </release>
     <release version="3.18.0-1" date="2021-07-10">
       <description>

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -1,8 +1,13 @@
 {
   "app-id": "org.claws_mail.Claws-Mail",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "23.08",
+  "runtime-version": "24.08",
   "sdk": "org.freedesktop.Sdk",
+  "sdk-extensions": ["org.freedesktop.Sdk.Extension.vala"],
+  "build-options": {
+    "prepend-path" : "/usr/lib/sdk/vala/bin/",
+    "prepend-ld-library-path" : "/usr/lib/sdk/vala/lib"
+  },
   "command": "claws-mail.sh",
   "finish-args": [
     "--share=ipc",
@@ -78,13 +83,16 @@
       "name": "libpoppler-glib",
       "buildsystem": "cmake-ninja",
       "config-opts": [
-        "-DENABLE_BOOST=OFF"
+        "-DCMAKE_BUILD_TYPE=release",
+        "-DENABLE_BOOST=OFF",
+        "-DENABLE_QT5=OFF",
+        "-DENABLE_QT6=OFF"
       ],
       "sources": [
         {
           "type": "archive",
-          "url": "https://gitlab.freedesktop.org/poppler/poppler/-/archive/poppler-22.11.0/poppler-poppler-22.11.0.tar.bz2",
-          "sha256": "b8f618d5c62030034d5c8da4d3f6a740260b7620b9a31021679ce1914d327f81"
+          "url": "https://gitlab.freedesktop.org/poppler/poppler/-/archive/poppler-24.11.0/poppler-poppler-24.11.0.tar.bz2",
+          "sha256": "241108ec50be654e4e35e93c18a555cf6a6bed0eb4210c3751491e53183e4172"
         }
       ],
       "cleanup": [
@@ -139,25 +147,6 @@
           "type": "archive",
           "url": "https://gitlab.com/graphviz/graphviz/-/archive/2.50.0/graphviz-2.50.0.tar.bz2",
           "sha256": "262b4285530f5804f656e643bfccf0e910fcfc483639921209e16fd7a04bebe0"
-        }
-      ],
-      "cleanup": [
-        "/libexec",
-        "/lib/pkgconfig",
-        "/include",
-        "*.a",
-        "*.la"
-      ]
-    },
-    {
-      "name": "vala",
-      "buildsystem": "autotools",
-      "config-opts": [],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://download.gnome.org/sources/vala/0.56/vala-0.56.3.tar.xz",
-          "sha256": "e1066221bf7b89cb1fa7327a3888645cb33b604de3bf45aa81132fd040b699bf"
         }
       ],
       "cleanup": [
@@ -341,6 +330,8 @@
         "--disable-pinentry-emacs",
         "--disable-inside-emacs",
         "--disable-pinentry-gnome3",
+        "--disable-pinentry-qt",
+        "--disable-pinentry-qt4",
         "--disable-pinentry-qt5",
         "--disable-pinentry-tty",
         "--disable-pinentry-tqt",
@@ -349,8 +340,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://gnupg.org/ftp/gcrypt/pinentry/pinentry-1.2.1.tar.bz2",
-          "sha256": "457a185e5a85238fb945a955dc6352ab962dc8b48720b62fc9fa48c7540a4067"
+          "url": "https://gnupg.org/ftp/gcrypt/pinentry/pinentry-1.3.1.tar.bz2",
+          "sha256": "bc72ee27c7239007ab1896c3c2fae53b076e2c9bd2483dc2769a16902bce8c04"
         }
       ]
     },

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -1,13 +1,8 @@
 {
   "app-id": "org.claws_mail.Claws-Mail",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "24.08",
+  "runtime-version": "23.08",
   "sdk": "org.freedesktop.Sdk",
-  "sdk-extensions": ["org.freedesktop.Sdk.Extension.vala"],
-  "build-options": {
-    "prepend-path" : "/usr/lib/sdk/vala/bin/",
-    "prepend-ld-library-path" : "/usr/lib/sdk/vala/lib"
-  },
   "command": "claws-mail.sh",
   "finish-args": [
     "--share=ipc",

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -453,8 +453,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://www.claws-mail.org//releases/claws-mail-4.2.0.tar.xz",
-          "sha256": "7c8ab1732d74197df06d61a6b7ebc7c580ecf6e92eb1ef6ae5b0107533f1af07"
+          "url": "https://www.claws-mail.org/releases/claws-mail-4.3.0.tar.xz",
+          "sha256": "95dc1d888eb916f028467fa0c3cbf45baff6678793b7bfb35fabba029d581ce1"
         },
         {
           "type": "patch",

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -3,7 +3,7 @@
   "runtime": "org.freedesktop.Platform",
   "runtime-version": "22.08",
   "sdk": "org.freedesktop.Sdk",
-  "command": "/app/bin/claws-mail.sh",
+  "command": "claws-mail.sh",
   "finish-args": [
     "--share=ipc",
     "--share=network",
@@ -214,7 +214,7 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download-fallback.gnome.org/sources/vala/0.56/vala-0.56.3.tar.xz",
+          "url": "https://download.gnome.org/sources/vala/0.56/vala-0.56.3.tar.xz",
           "sha256": "e1066221bf7b89cb1fa7327a3888645cb33b604de3bf45aa81132fd040b699bf"
         }
       ],
@@ -281,9 +281,9 @@
       "config-opts": [],
       "sources": [
         {
-          "type": "archive",
-          "url": "https://github.com/AbiWord/enchant/releases/download/v2.3.3/enchant-2.3.3.tar.gz",
-          "sha256": "3da12103f11cf49c3cf2fd2ce3017575c5321a489e5b9bfa81dd91ec413f3891"
+          "type": "git",
+          "url": "https://github.com/AbiWord/enchant.git",
+          "commit": "823df01a92a3dad9172f0ae1a0bcfe9d7039645b"
         }
       ],
       "cleanup": [
@@ -301,7 +301,7 @@
       "sources": [
         {
           "type": "archive",
-          "url": " http://libndp.org/files/libndp-1.8.tar.gz",
+          "url": "http://libndp.org/files/libndp-1.8.tar.gz",
           "sha256": "88ffb66ee2eb527f146f5c02f5ccbc38ba97d2b0d57eb46bfba488821ab0c02b"
         }
       ],
@@ -453,8 +453,12 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://claws-mail.org/releases/claws-mail-4.1.1.tar.xz",
-          "sha256": "b189e700c1896f5e0deb0b76d4bfa820eb7ac1935ee10aa9afbada3cf53a0344"
+          "url": "https://www.claws-mail.org//releases/claws-mail-4.2.0.tar.xz",
+          "sha256": "7c8ab1732d74197df06d61a6b7ebc7c580ecf6e92eb1ef6ae5b0107533f1af07"
+        },
+        {
+          "type": "patch",
+          "path": "patches/plugin-chooser.patch"
         }
       ],
       "cleanup": [

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.claws_mail.Claws-Mail",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "22.08",
+  "runtime-version": "23.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "claws-mail.sh",
   "finish-args": [
@@ -119,66 +119,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/google/gumbo-parser/archive/v0.10.1.tar.gz",
-          "sha256": "28463053d44a5dfbc4b77bcf49c8cee119338ffa636cc17fc3378421d714efad"
-        }
-      ],
-      "cleanup": [
-        "/lib/pkgconfig",
-        "/include",
-        "*.a",
-        "*.la"
-      ]
-    },
-    {
-      "name": "liboauth",
-      "buildsystem": "autotools",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/x42/liboauth/archive/c26f038eb9a4d97782e3f9f1e3da2b9356581869.zip",
-          "sha256": "ea0a98f256696842ba5fd600ad30088933c8d0939c4c4800f1a44a4b6941e4c4"
-        },
-        {
-          "type": "script",
-          "commands": [
-            "autoreconf -fi"
-          ]
-        }
-      ],
-      "cleanup": [
-        "/lib/pkgconfig",
-        "/include",
-        "*.a",
-        "*.la"
-      ]
-    },
-    {
-      "name": "libsoup",
-      "buildsystem": "meson",
-      "config-opts": [
-        "-Dintrospection=enabled",
-        "-Dgnome=false",
-        "-Dgtk_doc=false",
-        "-Dtests=false",
-        "-Dinstalled_tests=false"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://gitlab.gnome.org/GNOME/libsoup/-/archive/2.74.3/libsoup-2.74.3.tar.bz2",
-          "sha256": "eccb481b8e3586f917fa00251c23a3c25019f18bfe1b5e35bce9de257733545b"
-        }
-      ]
-    },
-    {
-      "name": "libuhttpmock",
-      "buildsystem": "autotools",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://gitlab.com/uhttpmock/uhttpmock/-/archive/0.5.3/uhttpmock-0.5.3.tar.gz",
-          "sha256": "17902a5bca494ec1fa2cbade1fde1be5387e4024fef63b3fc8dd555294233b13"
+          "url": "https://codeberg.org/gumbo-parser/gumbo-parser/archive/0.12.1.tar.gz",
+          "sha256": "c0bb5354e46539680724d638dbea07296b797229a7e965b13305c930ddc10d82"
         }
       ],
       "cleanup": [
@@ -216,29 +158,6 @@
           "type": "archive",
           "url": "https://download.gnome.org/sources/vala/0.56/vala-0.56.3.tar.xz",
           "sha256": "e1066221bf7b89cb1fa7327a3888645cb33b604de3bf45aa81132fd040b699bf"
-        }
-      ],
-      "cleanup": [
-        "/libexec",
-        "/lib/pkgconfig",
-        "/include",
-        "*.a",
-        "*.la"
-      ]
-    },
-    {
-      "name": "libgdata",
-      "buildsystem": "meson",
-      "config-opts": [
-        "-Dgoa=disabled",
-        "-Dgnome=disabled",
-        "-Dgtk_doc=false"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://gitlab.gnome.org/GNOME/libgdata/-/archive/0.18.1/libgdata-0.18.1.tar.bz2",
-          "sha256": "ed1e39db87914344cb8f1ab0d0f320aa662848816c466b879f75f46854439545"
         }
       ],
       "cleanup": [
@@ -444,7 +363,6 @@
         "--enable-pdf_viewer-plugin",
         "--enable-vcalendar-plugin",
         "--enable-litehtml_viewer-plugin",
-        "--enable-gdata-plugin",
         "--enable-bogofilter-plugin",
         "--disable-perl-plugin",
         "--disable-dillo-plugin",

--- a/patches/plugin-chooser.patch
+++ b/patches/plugin-chooser.patch
@@ -1,0 +1,160 @@
+diff --git a/src/gtk/filesel.c b/src/gtk/filesel.c
+index 41b9f89f7..8e5341ec7 100644
+--- a/src/gtk/filesel.c
++++ b/src/gtk/filesel.c
+@@ -247,3 +247,129 @@ gchar *filesel_select_file_save_folder(const gchar *title, const gchar *path)
+ 	return filesel_select_file (title, path, FALSE, TRUE, NULL);
+ }
+ 
++static GList *filesel_create_flatpak(const gchar *title, const gchar *path,
++			     gboolean multiple_files,
++			     gboolean open, gboolean folder_mode,
++			     const gchar *filter)
++{
++	GSList *slist = NULL, *slist_orig = NULL;
++	GList *list = NULL;
++
++	gint action = (open == TRUE) ?
++			(folder_mode == TRUE ? GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER:
++					       GTK_FILE_CHOOSER_ACTION_OPEN):
++			(folder_mode == TRUE ? GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER:
++					       GTK_FILE_CHOOSER_ACTION_SAVE);
++
++	gchar * action_btn = (open == TRUE) ? _("_Open"):_("_Save");
++	GtkWidget *chooser = gtk_file_chooser_dialog_new
++				(title, NULL, action,
++				_("_Cancel"), GTK_RESPONSE_CANCEL,
++				action_btn, GTK_RESPONSE_ACCEPT,
++				NULL);
++
++	gtk_file_chooser_set_local_only(GTK_FILE_CHOOSER(chooser), FALSE);
++
++	if (filter != NULL) {
++		GtkFileFilter *file_filter = gtk_file_filter_new();
++		gtk_file_filter_add_pattern(file_filter, filter);
++		gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(chooser),
++					    file_filter);
++	}
++
++	if (action == GTK_FILE_CHOOSER_ACTION_OPEN) {
++		GtkImage *preview;
++		preview = GTK_IMAGE(gtk_image_new ());
++		gtk_file_chooser_set_preview_widget (GTK_FILE_CHOOSER(chooser), GTK_WIDGET(preview));
++		g_signal_connect (chooser, "update-preview",
++			    G_CALLBACK (update_preview_cb), preview);
++
++	}
++
++	if (action == GTK_FILE_CHOOSER_ACTION_SAVE) {
++		gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
++	}
++
++	manage_window_set_transient (GTK_WINDOW(chooser));
++	gtk_window_set_modal(GTK_WINDOW(chooser), TRUE);
++
++	gtk_file_chooser_set_select_multiple (GTK_FILE_CHOOSER(chooser), multiple_files);
++
++	if (path && strlen(path) > 0) {
++		char *filename = NULL;
++		char *realpath = g_strdup(path);
++		char *tmp = NULL;
++		if (path[strlen(path)-1] == G_DIR_SEPARATOR) {
++			filename = "";
++		} else if ((filename = strrchr(path, G_DIR_SEPARATOR)) != NULL) {
++			filename++;
++			*(strrchr(realpath, G_DIR_SEPARATOR)+1) = '\0';
++		} else {
++			filename = (char *) path;
++			g_free(realpath);
++			realpath = g_strdup(get_home_dir());
++		}
++		if (g_utf8_validate(realpath, -1, NULL))
++			tmp = g_filename_from_utf8(realpath, -1, NULL, NULL, NULL);
++		if (tmp == NULL)
++			tmp = g_strdup(realpath);
++		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), tmp);
++		g_free(tmp);
++		if (action == GTK_FILE_CHOOSER_ACTION_SAVE) {
++			if (g_utf8_validate(filename, -1, NULL))
++				gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser),
++								  filename);
++		}
++		g_free(realpath);
++	} else {
++		gchar *tmp = NULL;
++		if (!prefs_common.attach_load_dir || !*prefs_common.attach_load_dir)
++			prefs_common.attach_load_dir = g_strdup_printf("%s%c", get_home_dir(), G_DIR_SEPARATOR);
++		if (g_utf8_validate(prefs_common.attach_load_dir, -1, NULL))
++			tmp = g_filename_from_utf8(prefs_common.attach_load_dir, -1, NULL, NULL, NULL);
++		if (tmp == NULL)
++			tmp = g_strdup(prefs_common.attach_load_dir);
++		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), tmp);
++		g_free(tmp);
++	}
++
++	if (gtk_dialog_run (GTK_DIALOG (chooser)) == GTK_RESPONSE_ACCEPT)
++		slist = gtk_file_chooser_get_filenames (GTK_FILE_CHOOSER (chooser));
++
++	manage_window_focus_out(chooser, NULL, NULL);
++	gtk_widget_destroy (chooser);
++
++	slist_orig = slist;
++
++	if (slist) {
++		gchar *tmp = g_strdup(slist->data);
++
++		if (!path && prefs_common.attach_load_dir)
++			g_free(prefs_common.attach_load_dir);
++
++		if (strrchr(tmp, G_DIR_SEPARATOR))
++			*(strrchr(tmp, G_DIR_SEPARATOR)+1) = '\0';
++
++		if (!path)
++			prefs_common.attach_load_dir = g_filename_to_utf8(tmp, -1, NULL, NULL, NULL);
++
++		g_free(tmp);
++	}
++
++	while (slist) {
++		list = g_list_append(list, slist->data);
++		slist = slist->next;
++	}
++
++	if (slist_orig)
++		g_slist_free(slist_orig);
++
++	return list;
++}
++
++GList *filesel_select_multiple_files_open_with_filter_flatpak(	const gchar *title,
++								const gchar *path,
++								const gchar *filter)
++{
++	return filesel_create_flatpak (title, path, TRUE, TRUE, FALSE, filter);
++}
+diff --git a/src/gtk/filesel.h b/src/gtk/filesel.h
+index 3a5aae684..03a31e697 100644
+--- a/src/gtk/filesel.h
++++ b/src/gtk/filesel.h
+@@ -34,4 +34,8 @@ GList *filesel_select_multiple_files_open_with_filter(	const gchar *title,
+ 							const gchar *path,
+ 							const gchar *filter);
+ 
++GList *filesel_select_multiple_files_open_with_filter_flatpak(	const gchar *title,
++								const gchar *path,
++								const gchar *filter);
++
+ #endif /* __FILESEL_H__ */
+diff --git a/src/gtk/pluginwindow.c b/src/gtk/pluginwindow.c
+index 4e6baf21a..dddac5e9b 100644
+--- a/src/gtk/pluginwindow.c
++++ b/src/gtk/pluginwindow.c
+@@ -196,7 +196,7 @@ static void load_cb(GtkButton *button, PluginWindow *pluginwindow)
+ {
+ 	GList *file_list;
+ 
+-	file_list = filesel_select_multiple_files_open_with_filter(
++	file_list = filesel_select_multiple_files_open_with_filter_flatpak(
+ 			_("Select the Plugins to load"), get_plugin_dir(), 
+ 			"*." G_MODULE_SUFFIX);
+ 


### PR DESCRIPTION
Upgraded to Claws-Mail 4.3.0 results in plugins being impossible to load, #34, because the file-loading dialog no longer provides access to flatpak application content.

Includes:
- #38
- #39
- #37
- #36
- #35, GData is no longer supported, so the plugin will disappear.