### PR TITLE
feat: update to version 4.2.0

### DIFF
--- a/org.claws_mail.Claws-Mail.appdata.xml
+++ b/org.claws_mail.Claws-Mail.appdata.xml
@@ -67,6 +67,55 @@
   </screenshots>
 
   <releases>
+    <release version="4.2.0" date="2023-11-20">
+      <description>
+      <p>Claws-Mail updated to 4.2.0.</p>
+      <ul>
+        <li>An easy way to open any folder on start-up has been added: Right-click a folder and choose 'Open on start-up'. This can also be configured on the 'Folder list' tab of the /Configuration/Preferences/Display/Summaries page.</li>
+        <li>Spam statistics have been added to the session statistics.</li>
+        <li>It is now possible to save message attachments only, without the other message parts.</li>
+        <li>QuickSearch: support for a "v H V" search expression has been added and the 'y S' expression has been removed ('v X-Label S' can be used instead).</li>
+        <li>font/* and chemical/* MIME types are now recognised.</li>
+        <li>The image viewer now works correctly when not auto-loading images.</li>
+        <li>Icon Themes: it is no longer possible to install or remove system themes.</li>
+        <li>IMAP: Support for SCRAM-SHA-{224,256,384,512} authentication</li>
+        <li>mechanisms has been added.</li>
+        <li>IMAP: The statusbar now shows that expunge is happening.</li>
+        <li>The GData plugin has been removed.</li>
+        <li>The Fancy plugin no longer requires libsoup or libsoup-gnome.</li>
+        <li>The LiteHTML Viewer plugin has been synchronised with litehtml 0.7.</li>
+        <li>The LiteHTML viewer plugin will now only be built automatically if libgumbo 0.12 or newer is available. Building with libgumbo 0.10 must be explicitly requested using --enable-litehtml_viewer-plugin.</li>
+        <li>For extra debug output use --enable-more-addressbook-debug and --enable-more-ldap-debug.</li>
+        <li>Added translation: Portuguese</li>
+        <li>Updated translations: Brazilian Portuguese, Catalan, Czech, French, Polish, Russian, Slovak, Spanish, Swedish, Traditional Chinese, Turkish.</li>
+      </ul>
+      <p>Bug fixes</p>
+      <ul>
+        <li>bug 4491, 'address autocompletion list does not expand in height with the number of matches'</li>
+        <li>bug 4618, 'Rate limit by remote breaks queued/marked actions (Delete/Move)'</li>
+        <li>bug 4631, 'Embedding external editor crashes Claws-Mail on Wayland'</li>
+        <li>bug 4637, 'Segmentation fault when using SUMMARY is empty'</li>
+        <li>bug 4645, 'fails to check for perl-ExtUtils::Embed'</li>
+        <li>bug 4648, 'fails to build with gcc 13'</li>
+        <li>bug 4658, 'Headers unfolded incorrectly in message view'</li>
+        <li>bug 4664, 'OAUTH2 overwrites passwords even for plaintext logins'</li>
+        <li>bug 4666, 'fancy plugin doesn't build with libwebkit2gtk-4.1'</li>
+        <li>bug 4670, 'To/CC incorrectly escaped with a trailing backslash'</li>
+        <li>bug 4679, 'The correct date header is interpreted incorrectly to display strange date.'</li>
+        <li>bug 4693, 'Hang and crash when enable disable SVG Rendering prefs'</li>
+        <li>when starting with msgview hidden, toggling msgview to show it would use incorrect height</li>
+        <li>update quicksearch history list when changing type </li>
+        <li>wrong message which is shown when mail can't be sent</li>
+        <li>when redirecting, disable queueing</li>
+        <li>arbitrary paste restriction</li>
+        <li>when queueing or drafting a msg with an attachment which no longer exists, use the correct label on the button of the warning dialogue</li>
+        <li>using a custom header in found_in_addressbook match expressions</li>
+        <li>URIs may contain the '$' dollar sign</li>
+        <li>OAuth2, Update on-disk tokens as well when in-memory tokens are updated</li>
+        <li>Microsoft POP3 OAuth2 protocol</li>
+      </ul>
+      </description>
+    </release>
     <release version="4.1.0" date="2022-04-03">
       <description>
       <p>Claws-Mail updated to 4.1.0.</p>

--- a/org.claws_mail.Claws-Mail.appdata.xml
+++ b/org.claws_mail.Claws-Mail.appdata.xml
@@ -5,7 +5,9 @@
   <name>Claws-Mail</name>
   <project_license>GPL-3.0-only</project_license>
   <metadata_license>CC0-1.0</metadata_license>
-  <developer_name>The Claws Mail Team</developer_name>
+  <developer id="org.claws-mail">
+    <name>The Claws Mail Team</name>
+  </developer>
   <summary>Claws Mail is an email client (and news reader), based on GTK+</summary>
   <url type="homepage">https://claws-mail.org/</url>
 
@@ -25,42 +27,48 @@
     <p>This is an unofficial package. (See package metadata for details.)</p>
   </description>
 
-  <icon type="remote" height="128" width="128">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/share/icons/hicolor/128x128/apps/claws-mail.png</icon>
-  <icon type="remote" height="64" width="64">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/share/icons/hicolor/64x64/apps/claws-mail.png</icon>
-  <icon type="remote" height="48" width="48">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/share/icons/hicolor/48x48/apps/claws-mail.png</icon>
+  <icon type="remote" height="128" width="128">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/static/claws-mail-128x128.png</icon>
+  <icon type="remote" height="64" width="64">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/static/claws-mail-64x64.png</icon>
+  <icon type="remote" height="48" width="48">https://github.com/flathub/org.claws_mail.Claws-Mail/raw/master/static/claws-mail-48x48.png</icon>
   
   <launchable type="desktop-id">org.claws_mail.Claws-Mail.desktop</launchable>
 
   <screenshots>
-    <screenshot>
+    <screenshot type="default">
       <image type="source">
         https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-main-window.png
       </image>
+      <caption>The main window</caption>
     </screenshot>
     <screenshot>
       <image type="source">
         https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-compose-window.png
       </image>
+      <caption>The compose window</caption>
     </screenshot>
     <screenshot>
       <image type="source">
         https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-reading-mail.png
       </image>
+      <caption>The separate message view</caption>
     </screenshot>
     <screenshot>
       <image type="source">
         https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-current-features.png
       </image>
+      <caption>The currenlty supported features</caption>
     </screenshot>
     <screenshot>
       <image type="source">
         https://raw.githubusercontent.com/flathub/org.claws_mail.Claws-Mail/379b411ceda0d0fb6f612c94eed008724df674eb/screenshots/claws-mail-current-plugins.png
       </image>
+      <caption>The currenlty enabled plugins</caption>
     </screenshot>
   </screenshots>
 
   <releases>
     <release version="4.1.0" date="2022-04-03">
+      <description>
       <p>Claws-Mail updated to 4.1.0.</p>
       <ul>
         <li>>Text zooming in the Message View is now possible, using CTRL+mouse wheel up/down, CRTL+touchpad two-fingered vertical swiping, or the Message View's right-click menu.</li>
@@ -119,8 +127,10 @@
         <li>weird logic with the 'Edit filter action' dialog</li>
         <li>resource leaks; memory corruption</li>
       </ul>
+      </description>
     </release>
     <release version="4.0.0-1" date="2021-11-20">
+      <description>
         <p>Claws-Mail 4.0.0</p>
         <ul>
             <li>First release using GTK-3 toolkit.</li>
@@ -132,13 +142,16 @@
             <li>Spell-checking support enabled.</li>
             <li>Extended notifications support enabled.</li>
         </ul>
+      </description>
     </release>
     <release version="4.0.0" date="2021-11-12">
+      <description>
         <p>Claws-Mail updated to 4.0.0</p>
         <ul>
             <li>First release using GTK-3 toolkit.</li>
         </ul>
-        <p><i>Flatpak packaging note</i>: the gpg-agent will no longer be started inside the flatpak package if it is not running. Please make sure that gpg-agent is running on the host system if you rely on access to smartcards/security keys.</p>
+        <p><em>Flatpak packaging note</em>: the gpg-agent will no longer be started inside the flatpak package if it is not running. Please make sure that gpg-agent is running on the host system if you rely on access to smartcards/security keys.</p>
+      </description>
     </release>
     <release version="3.18.0-1" date="2021-07-10">
       <description>

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -281,9 +281,9 @@
       "config-opts": [],
       "sources": [
         {
-          "type": "archive",
-          "url": "https://github.com/AbiWord/enchant/archive/refs/tags/v2.3.3.tar.gz",
-          "sha256": "5952a792570eb232af464331b537381aca8bc711a1d8c4251e1f035e9cca8cfb"
+          "type": "git",
+          "url": "https://github.com/AbiWord/enchant.git",
+          "commit": "823df01a92a3dad9172f0ae1a0bcfe9d7039645b"
         }
       ],
       "cleanup": [

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -453,8 +453,12 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://claws-mail.org/releases/claws-mail-4.1.1.tar.xz",
-          "sha256": "b189e700c1896f5e0deb0b76d4bfa820eb7ac1935ee10aa9afbada3cf53a0344"
+          "url": "https://www.claws-mail.org//releases/claws-mail-4.2.0.tar.xz",
+          "sha256": "7c8ab1732d74197df06d61a6b7ebc7c580ecf6e92eb1ef6ae5b0107533f1af07"
+        },
+        {
+          "type": "patch",
+          "path": "patches/plugin-chooser.patch"
         }
       ],
       "cleanup": [

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -3,7 +3,7 @@
   "runtime": "org.freedesktop.Platform",
   "runtime-version": "22.08",
   "sdk": "org.freedesktop.Sdk",
-  "command": "/app/bin/claws-mail.sh",
+  "command": "claws-mail.sh",
   "finish-args": [
     "--share=ipc",
     "--share=network",

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -282,8 +282,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/AbiWord/enchant/releases/download/v2.3.3/enchant-2.3.3.tar.gz",
-          "sha256": "3da12103f11cf49c3cf2fd2ce3017575c5321a489e5b9bfa81dd91ec413f3891"
+          "url": "https://github.com/AbiWord/enchant/archive/refs/tags/v2.3.3.tar.gz",
+          "sha256": "5952a792570eb232af464331b537381aca8bc711a1d8c4251e1f035e9cca8cfb"
         }
       ],
       "cleanup": [

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -301,7 +301,7 @@
       "sources": [
         {
           "type": "archive",
-          "url": " http://libndp.org/files/libndp-1.8.tar.gz",
+          "url": "http://libndp.org/files/libndp-1.8.tar.gz",
           "sha256": "88ffb66ee2eb527f146f5c02f5ccbc38ba97d2b0d57eb46bfba488821ab0c02b"
         }
       ],

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -214,7 +214,7 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download-fallback.gnome.org/sources/vala/0.56/vala-0.56.3.tar.xz",
+          "url": "https://download.gnome.org/sources/vala/0.56/vala-0.56.3.tar.xz",
           "sha256": "e1066221bf7b89cb1fa7327a3888645cb33b604de3bf45aa81132fd040b699bf"
         }
       ],

--- a/patches/plugin-chooser.patch
+++ b/patches/plugin-chooser.patch
@@ -1,0 +1,160 @@
+diff --git a/src/gtk/filesel.c b/src/gtk/filesel.c
+index 41b9f89f7..8e5341ec7 100644
+--- a/src/gtk/filesel.c
++++ b/src/gtk/filesel.c
+@@ -247,3 +247,129 @@ gchar *filesel_select_file_save_folder(const gchar *title, const gchar *path)
+ 	return filesel_select_file (title, path, FALSE, TRUE, NULL);
+ }
+ 
++static GList *filesel_create_flatpak(const gchar *title, const gchar *path,
++			     gboolean multiple_files,
++			     gboolean open, gboolean folder_mode,
++			     const gchar *filter)
++{
++	GSList *slist = NULL, *slist_orig = NULL;
++	GList *list = NULL;
++
++	gint action = (open == TRUE) ?
++			(folder_mode == TRUE ? GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER:
++					       GTK_FILE_CHOOSER_ACTION_OPEN):
++			(folder_mode == TRUE ? GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER:
++					       GTK_FILE_CHOOSER_ACTION_SAVE);
++
++	gchar * action_btn = (open == TRUE) ? _("_Open"):_("_Save");
++	GtkWidget *chooser = gtk_file_chooser_dialog_new
++				(title, NULL, action,
++				_("_Cancel"), GTK_RESPONSE_CANCEL,
++				action_btn, GTK_RESPONSE_ACCEPT,
++				NULL);
++
++	gtk_file_chooser_set_local_only(GTK_FILE_CHOOSER(chooser), FALSE);
++
++	if (filter != NULL) {
++		GtkFileFilter *file_filter = gtk_file_filter_new();
++		gtk_file_filter_add_pattern(file_filter, filter);
++		gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(chooser),
++					    file_filter);
++	}
++
++	if (action == GTK_FILE_CHOOSER_ACTION_OPEN) {
++		GtkImage *preview;
++		preview = GTK_IMAGE(gtk_image_new ());
++		gtk_file_chooser_set_preview_widget (GTK_FILE_CHOOSER(chooser), GTK_WIDGET(preview));
++		g_signal_connect (chooser, "update-preview",
++			    G_CALLBACK (update_preview_cb), preview);
++
++	}
++
++	if (action == GTK_FILE_CHOOSER_ACTION_SAVE) {
++		gtk_dialog_set_default_response(GTK_DIALOG(chooser), GTK_RESPONSE_ACCEPT);
++	}
++
++	manage_window_set_transient (GTK_WINDOW(chooser));
++	gtk_window_set_modal(GTK_WINDOW(chooser), TRUE);
++
++	gtk_file_chooser_set_select_multiple (GTK_FILE_CHOOSER(chooser), multiple_files);
++
++	if (path && strlen(path) > 0) {
++		char *filename = NULL;
++		char *realpath = g_strdup(path);
++		char *tmp = NULL;
++		if (path[strlen(path)-1] == G_DIR_SEPARATOR) {
++			filename = "";
++		} else if ((filename = strrchr(path, G_DIR_SEPARATOR)) != NULL) {
++			filename++;
++			*(strrchr(realpath, G_DIR_SEPARATOR)+1) = '\0';
++		} else {
++			filename = (char *) path;
++			g_free(realpath);
++			realpath = g_strdup(get_home_dir());
++		}
++		if (g_utf8_validate(realpath, -1, NULL))
++			tmp = g_filename_from_utf8(realpath, -1, NULL, NULL, NULL);
++		if (tmp == NULL)
++			tmp = g_strdup(realpath);
++		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), tmp);
++		g_free(tmp);
++		if (action == GTK_FILE_CHOOSER_ACTION_SAVE) {
++			if (g_utf8_validate(filename, -1, NULL))
++				gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser),
++								  filename);
++		}
++		g_free(realpath);
++	} else {
++		gchar *tmp = NULL;
++		if (!prefs_common.attach_load_dir || !*prefs_common.attach_load_dir)
++			prefs_common.attach_load_dir = g_strdup_printf("%s%c", get_home_dir(), G_DIR_SEPARATOR);
++		if (g_utf8_validate(prefs_common.attach_load_dir, -1, NULL))
++			tmp = g_filename_from_utf8(prefs_common.attach_load_dir, -1, NULL, NULL, NULL);
++		if (tmp == NULL)
++			tmp = g_strdup(prefs_common.attach_load_dir);
++		gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(chooser), tmp);
++		g_free(tmp);
++	}
++
++	if (gtk_dialog_run (GTK_DIALOG (chooser)) == GTK_RESPONSE_ACCEPT)
++		slist = gtk_file_chooser_get_filenames (GTK_FILE_CHOOSER (chooser));
++
++	manage_window_focus_out(chooser, NULL, NULL);
++	gtk_widget_destroy (chooser);
++
++	slist_orig = slist;
++
++	if (slist) {
++		gchar *tmp = g_strdup(slist->data);
++
++		if (!path && prefs_common.attach_load_dir)
++			g_free(prefs_common.attach_load_dir);
++
++		if (strrchr(tmp, G_DIR_SEPARATOR))
++			*(strrchr(tmp, G_DIR_SEPARATOR)+1) = '\0';
++
++		if (!path)
++			prefs_common.attach_load_dir = g_filename_to_utf8(tmp, -1, NULL, NULL, NULL);
++
++		g_free(tmp);
++	}
++
++	while (slist) {
++		list = g_list_append(list, slist->data);
++		slist = slist->next;
++	}
++
++	if (slist_orig)
++		g_slist_free(slist_orig);
++
++	return list;
++}
++
++GList *filesel_select_multiple_files_open_with_filter_flatpak(	const gchar *title,
++								const gchar *path,
++								const gchar *filter)
++{
++	return filesel_create_flatpak (title, path, TRUE, TRUE, FALSE, filter);
++}
+diff --git a/src/gtk/filesel.h b/src/gtk/filesel.h
+index 3a5aae684..03a31e697 100644
+--- a/src/gtk/filesel.h
++++ b/src/gtk/filesel.h
+@@ -34,4 +34,8 @@ GList *filesel_select_multiple_files_open_with_filter(	const gchar *title,
+ 							const gchar *path,
+ 							const gchar *filter);
+ 
++GList *filesel_select_multiple_files_open_with_filter_flatpak(	const gchar *title,
++								const gchar *path,
++								const gchar *filter);
++
+ #endif /* __FILESEL_H__ */
+diff --git a/src/gtk/pluginwindow.c b/src/gtk/pluginwindow.c
+index 4e6baf21a..dddac5e9b 100644
+--- a/src/gtk/pluginwindow.c
++++ b/src/gtk/pluginwindow.c
+@@ -196,7 +196,7 @@ static void load_cb(GtkButton *button, PluginWindow *pluginwindow)
+ {
+ 	GList *file_list;
+ 
+-	file_list = filesel_select_multiple_files_open_with_filter(
++	file_list = filesel_select_multiple_files_open_with_filter_flatpak(
+ 			_("Select the Plugins to load"), get_plugin_dir(), 
+ 			"*." G_MODULE_SUFFIX);
+ 


### PR DESCRIPTION
This is my first attempt to update to 4.2 with working plugin chooser.

This PR updates Claws Mail to 4.2.0 and adds a patch that adds single function, `filesel_create_flatpak`. It is basically an old version of `filesel_create` that uses in-sandbox file chooser. Thus, it allows to browse files in sandbox.

It has a downside that in order to load a third-party plugin, it has to be shared with flatpak using filesystem permissions. I think it is a fair tradeoff to have built-in ones working.

It is only used in one place, plugin file chooser. Therefore, no other functionality should be affected.

It will start as a draft to check if builds pass and if it actually works.

Closes #34
Closes #38
