### PR TITLE
enchant - use archive source

### DIFF
--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -184,9 +184,14 @@
       "config-opts": [],
       "sources": [
         {
-          "type": "git",
-          "url": "https://github.com/AbiWord/enchant.git",
-          "commit": "823df01a92a3dad9172f0ae1a0bcfe9d7039645b"
+          "type": "archive",
+          "url": "https://github.com/AbiWord/enchant/archive/refs/tags/v2.3.3.tar.gz",
+          "sha256": "5952a792570eb232af464331b537381aca8bc711a1d8c4251e1f035e9cca8cfb"
+        },
+        {
+          "type": "archive",
+          "url": "https://github.com/coreutils/gnulib/archive/refs/tags/v1.0.tar.gz",
+          "sha256": "c3585637eeab2268400f26a7174862d72c416e9476a0ff4ec12ebce646a0f477"
         }
       ],
       "cleanup": [


### PR DESCRIPTION
Due to constant issues with GNU Savannah Git server that pop up recently, I try to make this build to rely on plain archives from GitHub