### PR TITLE
Flatpak extension entrypoint for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ Claws-Mail with the following plug-ins:
 - TNEF parser
 - vCalendar
 
+### Extra plugins
+
+This application provides a [Flatpak extension](https://docs.flatpak.org/en/latest/extension.html) entrypoint to install additional plugins as Flatpak extensions.
+
+As of the time of writing, there are no extra plugins published yet but most up-to-date information take a look [here](https://flathub.org/apps/org.claws_mail.Claws-Mail) -> bottom of the page -> 'Addons'.
+
+#### For plugin developers/packagers
+
+Plugin files should be installed into `/app/extra-plugins/<PLUGIN_NAME>` as installation prefix, such as binaries are installed into `/app/extra-plugins/<PLUGIN_NAME>/bin` and libraries are installed into `/app/extra-plugins/<PLUGIN_NAME>/lib`, etc.
+
+#### For plugin users
+
+Plugins will follow naming convention of `org.claws_mail.Claws.Mail.Plugin.<PLUGIN_NAME>`. Inside Flatpak sandbox, plugin will be available under `/app/extra-plugins/<PLUGIN_NAME>`. For convenience, there's `/app/etra-plugins/lib` directory that combines libraries from all plugins. No need to look for plugin shared library in plugin-specific directory - it is all in one place.
+
 ## Packaging details
 
 ### Dependencies

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -13,8 +13,19 @@
     "--system-talk-name=org.freedesktop.NetworkManager",
     "--talk-name=org.freedesktop.Notifications",
     "--filesystem=home",
-    "--filesystem=xdg-run/gnupg:ro"
+    "--filesystem=xdg-run/gnupg:ro",
+    "--env=PATH=/app/bin:/usr/bin:/app/extra-plugins/bin"
   ],
+  "add-extensions": {
+    "org.claws_mail.ClawsMail.Plugin": {
+      "directory": "extra-plugins",
+      "subdirectories": true,
+      "merge-dirs": "lib;bin;share",
+      "add-ld-path": "lib",
+      "autodelete": true,
+      "no-autodownload": true
+    }
+  },
   "modules": [
     {
       "name": "libetpan",
@@ -354,6 +365,9 @@
         "--disable-perl-plugin",
         "--disable-dillo-plugin",
         "--disable-bsfilter-plugin"
+      ],
+      "post-install": [
+        "mkdir -p ${FLATPAK_DEST}/extra-plugins"
       ],
       "sources": [
         {


### PR DESCRIPTION
This change allows to install plugin for Claws Mail as Flatpak extension and be automatically picked up by Flatpak so it is available inside sandbox. Flatpak docs [here](https://docs.flatpak.org/en/latest/extension.html).

There are no plugins yet. However, it might be an 'escape hatch' for complex plugins like Python one - there's possibility to implement it as separate Flatpak project - a Flatpak extension.