### PR TITLE
chore: bump runtime version

### DIFF
--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -73,8 +73,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/uclouvain/openjpeg/archive/refs/tags/v2.4.0.tar.gz",
-          "sha256": "8702ba68b442657f11aaeb2b338443ca8d5fb95b0d845757968a7be31ef7f16d"
+          "url": "https://github.com/uclouvain/openjpeg/archive/refs/tags/v2.5.4.tar.gz",
+          "sha256": "a695fbe19c0165f295a8531b1e4e855cd94d0875d2f88ec4b61080677e27188a"
         }
       ],
       "cleanup": [

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -111,11 +111,14 @@
     {
       "name": "libical",
       "buildsystem": "cmake-ninja",
+      "config-opts": [
+        "-DENABLE_GTK_DOC=OFF"
+      ],
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/libical/libical/releases/download/v3.0.16/libical-3.0.16.tar.gz",
-          "sha256": "b44705dd71ca4538c86fb16248483ab4b48978524fb1da5097bd76aa2e0f0c33"
+          "url": "https://github.com/libical/libical/releases/download/v3.0.20/libical-3.0.20.tar.gz",
+          "sha256": "e73de92f5a6ce84c1b00306446b290a2b08cdf0a80988eca0a2c9d5c3510b4c2"
         }
       ],
       "cleanup": [

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -195,9 +195,9 @@
       "config-opts": [],
       "sources": [
         {
-          "type": "git",
-          "url": "https://github.com/AbiWord/enchant.git",
-          "commit": "823df01a92a3dad9172f0ae1a0bcfe9d7039645b"
+          "type": "archive",
+          "url": "https://github.com/rrthomas/enchant/releases/download/v2.3.3/enchant-2.3.3.tar.gz",
+          "sha256": "3da12103f11cf49c3cf2fd2ce3017575c5321a489e5b9bfa81dd91ec413f3891"
         }
       ],
       "cleanup": [

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.claws_mail.Claws-Mail",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "23.08",
+  "runtime-version": "25.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "claws-mail.sh",
   "finish-args": [

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -14,7 +14,8 @@
     "--talk-name=org.freedesktop.Notifications",
     "--filesystem=home",
     "--filesystem=xdg-run/gnupg:ro",
-    "--env=PATH=/app/bin:/usr/bin:/app/extra-plugins/bin"
+    "--env=PATH=/app/bin:/usr/bin:/app/extra-plugins/bin",
+    "--env=GDK_PIXBUF_MODULE_FILE=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
   ],
   "add-extensions": {
     "org.claws_mail.ClawsMail.Plugin": {
@@ -355,6 +356,44 @@
       ]
     },
     "shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json",
+    {
+      "name": "gdk-pixbuf-loaders-others",
+      "buildsystem": "meson",
+      "config-opts": [
+        "-Dgtk_doc=false",
+        "-Dman=false",
+        "-Dintrospection=disabled",
+        "-Dinstalled_tests=false",
+        "-Dtests=false",
+        "-Ddocumentation=false",
+        "-Dglycin=disabled",
+        "-Dandroid=disabled",
+        "-Dbuiltin_loaders=none",
+        "-Dpng=disabled",
+        "-Dtiff=disabled",
+        "-Djpeg=disabled",
+        "-Dgif=disabled",
+        "-Dothers=enabled"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/archive/2.44.3/gdk-pixbuf-2.44.3.tar.gz",
+          "sha256": "cc591e3949a95e2f7b50173c9373df8846648b15aa596d9e7ec7258381bfac0d"
+        }
+      ],
+      "post-install": [
+        "GDK_PIXBUF_MODULEDIR=${FLATPAK_DEST}/lib/gdk-pixbuf-2.0/2.10.0/loaders gdk-pixbuf-query-loaders > ${FLATPAK_DEST}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache",
+        "gdk-pixbuf-query-loaders >> ${FLATPAK_DEST}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+      ],
+      "cleanup": [
+        "/bin",
+        "/include",
+        "/share",
+        "/lib/pkgconfig",
+        "/lib/libgdk_pixbuf-2.0.so.*"
+      ]
+    },
     {
       "name": "claws-mail",
       "buildsystem": "autotools",


### PR DESCRIPTION
Hello,
runtime 23.08 is EOL now and with this PR I want to update it to latest available version.