### PR TITLE
Drop libsecret and libnotify modules

### DIFF
--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -282,31 +282,6 @@
       ]
     },
     "shared-modules/dbus-glib/dbus-glib.json",
-    {
-      "name": "libnotify",
-      "buildsystem": "meson",
-      "config-opts": [
-        "-Dtests=false",
-        "-Dintrospection=disabled",
-        "-Dman=false",
-        "-Dgtk_doc=false"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://gitlab.gnome.org/GNOME/libnotify/-/archive/0.8.1/libnotify-0.8.1.tar.bz2",
-          "sha256": "6a17cd1eacc17c2dd2620e68da2b25151f08489ca17210ae32ae4b8c16e46889"
-        }
-      ],
-      "cleanup": [
-        "/libexec",
-        "/lib/pkgconfig",
-        "/lib/cmake",
-        "/include",
-        "*.a",
-        "*.la"
-      ]
-    },
     "shared-modules/libcanberra/libcanberra.json",
     {
       "name": "pcsc-lite",

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -332,7 +332,6 @@
       ]
     },
     "shared-modules/gtk2/gtk2.json",
-    "shared-modules/libsecret/libsecret.json",
     {
       "name": "pinentry",
       "buildsystem": "autotools",


### PR DESCRIPTION
Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10 and 5.15-25.08) provides libsecret; therefore, it no longer needs to be compiled (unless the project requires a specific version of this dependency).

Fixes: https://github.com/flathub/org.claws_mail.Claws-Mail/issues/48
Fixes: https://github.com/flathub/org.claws_mail.Claws-Mail/issues/50