### PR TITLE
Add vcs-browser URL

### DIFF
--- a/org.claws_mail.Claws-Mail.appdata.xml
+++ b/org.claws_mail.Claws-Mail.appdata.xml
@@ -10,6 +10,7 @@
   </developer>
   <summary>Claws Mail is an email client (and news reader), based on GTK+</summary>
   <url type="homepage">https://claws-mail.org/</url>
+  <url type="vcs-browser">https://git.claws-mail.org/?p=claws.git;a=summary</url>
 
   <description>
     <p>Claws Mail is an email client (and news reader), based on GTK+, featuring:</p>


### PR DESCRIPTION
I saw warnings in #48 about missing `vcs-browser` link so this PR adds it to metadata file. As per [guidelines](https://git.claws-mail.org/?p=claws.git;a=summary), it should be a link to the app source code.