### PR TITLE
feat: make sure that single instance of Claws Mail is running at a time

### DIFF
--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -20,7 +20,7 @@
     "--filesystem=xdg-run/gnupg:ro",
     "--env=PATH=/app/bin:/usr/bin:/app/extra-plugins/bin",
     "--env=GDK_PIXBUF_MODULE_FILE=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache",
-    "--filesystem=xdg-run/claws-mail:create"
+    "--allow=per-app-dev-shm"
   ],
   "add-extensions": {
     "org.claws_mail.ClawsMail.Plugin": {
@@ -425,6 +425,10 @@
         {
           "type": "patch",
           "path": "patches/plugin-chooser.patch"
+        },
+        {
+          "type": "patch",
+          "path": "patches/socket-dir.patch"
         }
       ],
       "cleanup": [

--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -19,7 +19,8 @@
     "--filesystem=home",
     "--filesystem=xdg-run/gnupg:ro",
     "--env=PATH=/app/bin:/usr/bin:/app/extra-plugins/bin",
-    "--env=GDK_PIXBUF_MODULE_FILE=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"
+    "--env=GDK_PIXBUF_MODULE_FILE=/app/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache",
+    "--filesystem=xdg-run/claws-mail:create"
   ],
   "add-extensions": {
     "org.claws_mail.ClawsMail.Plugin": {

--- a/patches/socket-dir.patch
+++ b/patches/socket-dir.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main.c b/src/main.c
+index 6fd7502..973777e 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -2241,7 +2241,7 @@ gchar *claws_get_socket_name(void)
+ 		gint stat_ok;
+ 
+ 		socket_dir = g_strdup_printf("%s%cclaws-mail",
+-					   g_get_user_runtime_dir(), G_DIR_SEPARATOR);
++					   "/dev/shm", G_DIR_SEPARATOR);
+ 		stat_ok = g_stat(socket_dir, &st);
+ 		if (stat_ok < 0 && errno != ENOENT) {
+ 			g_print("Error stat'ing socket_dir %s: %s\n",


### PR DESCRIPTION
As per source code: https://git.claws-mail.org/?p=claws.git;a=blob;f=src/main.c;h=fa9cba13e6b262c2d6d795ebbff96f7939825b0b;hb=HEAD#l2263

if there's already a socket present, executing `claws-mail` will only bring up the already existing application window.
It depened on `XDG_RUNTIME_DIR` which is not currently configurable. So to make it work (single instance of claws mail) I've added another directory to host which is `$XDG_RUNTIME_DIR/claws-mail` with ability to create it, to finish args.

With that change, we can easily have a single instance of claws-mail running.