### PR TITLE
Use openjpeg module from runtime

### DIFF
--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -73,24 +73,6 @@
       ]
     },
     {
-      "name": "libopenjpeg",
-      "buildsystem": "cmake-ninja",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/uclouvain/openjpeg/archive/refs/tags/v2.5.4.tar.gz",
-          "sha256": "a695fbe19c0165f295a8531b1e4e855cd94d0875d2f88ec4b61080677e27188a"
-        }
-      ],
-      "cleanup": [
-        "/lib/pkgconfig",
-        "/lib/openjpeg-*",
-        "/include",
-        "*.a",
-        "*.la"
-      ]
-    },
-    {
       "name": "libpoppler-glib",
       "buildsystem": "cmake-ninja",
       "config-opts": [


### PR DESCRIPTION
Freedesktop runtime version 25.08 appears to provide the **openjpeg** module.

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration.

**Related manifest file**

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/openjpeg.bst

Fixes: https://github.com/flathub/org.claws_mail.Claws-Mail/issues/55