### PR TITLE
feat: link with openldap

### DIFF
--- a/org.claws_mail.Claws-Mail.json
+++ b/org.claws_mail.Claws-Mail.json
@@ -431,6 +431,45 @@
         "/include",
         "*.a",
         "*.la"
+      ],
+      "modules": [
+        {
+          "name": "openldap",
+          "buildsystem": "autotools",
+          "config-opts": [
+            "--disable-debug",
+            "--enable-dynamic",
+            "--disable-syslog",
+            "--enable-ipv6",
+            "--enable-local",
+            "--disable-slapd",
+            "--disable-backends",
+            "--disable-overlays",
+            "--disable-argon2",
+            "--disable-balancer",
+            "--disable-static",
+            "--enable-shared",
+            "--with-cyrus-sasl",
+            "--without-systemd",
+            "--with-threads",
+            "--with-tls=gnutls",
+            "--with-mp",
+            "--with-odbc=auto"
+          ],
+          "sources": [
+            {
+              "type": "archive",
+              "url": "https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.6.12.tgz",
+              "sha256": "1716ad779e85d743694c3e3b05277fb71b6a5eadca43c7a958aa62683b22208e"
+            }
+          ],
+          "cleanup": [
+            "/lib/pkgconfig",
+            "/include",
+            "/share/man",
+            "*.la"
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
Add openldap to manifest. Claws Mail automatically detects it and links against.

Note: I'm using modules to Claws Mail module itself - it's gonna help long term with builds because now they're horribly long on my machine due to cache invalidation. 

Closes #54 